### PR TITLE
Made logger warn about WorldBorderAPI not being installed

### DIFF
--- a/src/main/java/world/bentobox/border/Border.java
+++ b/src/main/java/world/bentobox/border/Border.java
@@ -18,7 +18,7 @@ public final class Border extends Addon {
         Plugin plugin = Bukkit.getPluginManager().getPlugin("WorldBorderAPI");
 
         if (plugin == null || !plugin.isEnabled()) {
-            getLogger().info("WorldBorderAPI not found. Download from https://github.com/yannicklamprecht/WorldBorderAPI/releases");
+            getLogger().warning("WorldBorderAPI not found. Download from https://github.com/yannicklamprecht/WorldBorderAPI/releases");
             this.setState(State.DISABLED);
             return;
         }


### PR DESCRIPTION
Fixed:
[19:09:19] [Server thread/WARN]: [BentoBox] WorldBorderAPI not found. Download from https://github.com/yannicklamprecht/WorldBorderAPI/releases