### PR TITLE
Fixes barrier blocks not removing on protection range change

### DIFF
--- a/src/main/java/world/bentobox/border/Settings.java
+++ b/src/main/java/world/bentobox/border/Settings.java
@@ -1,0 +1,37 @@
+package world.bentobox.border;
+
+import world.bentobox.bentobox.api.configuration.ConfigComment;
+import world.bentobox.bentobox.api.configuration.ConfigEntry;
+import world.bentobox.bentobox.api.configuration.ConfigObject;
+import world.bentobox.bentobox.api.configuration.StoreAt;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@StoreAt(filename = "config.yml", path = "addons/Border")
+public class Settings implements ConfigObject {
+
+    @ConfigComment("")
+    @ConfigComment("This list stores GameModes in which Border addon should not work.")
+    @ConfigComment("To disable addon it is necessary to write its name in new line that starts with -. Example:")
+    @ConfigComment("disabled-gamemodes:")
+    @ConfigComment(" - BSkyBlock")
+    @ConfigEntry(path = "disabled-gamemodes")
+    private Set<String> disabledGameModes = new HashSet<>();
+    
+    /**
+     * @param disabledGameModes new disabledGameModes value.
+     */
+    public void setDisabledGameModes(Set<String> disabledGameModes)
+    {
+        this.disabledGameModes = disabledGameModes;
+    }
+
+    /**
+     * @return disabledGameModes value.
+     */
+    public Set<String> getDisabledGameModes()
+    {
+        return this.disabledGameModes;
+    }
+}

--- a/src/main/java/world/bentobox/border/listeners/PlayerBorder.java
+++ b/src/main/java/world/bentobox/border/listeners/PlayerBorder.java
@@ -71,6 +71,10 @@ public class PlayerBorder implements Listener {
      * @param island - island
      */
     public void showBarrier(Player player, Island island) {
+
+        if (addon.getSettings().getDisabledGameModes().contains(island.getGameMode()))
+            return;
+
         if (!User.getInstance(player).getMetaData(BORDER_STATE).map(MetaDataValue::asBoolean).orElse(false)) {
             return;
         }

--- a/src/main/java/world/bentobox/border/listeners/PlayerBorder.java
+++ b/src/main/java/world/bentobox/border/listeners/PlayerBorder.java
@@ -18,6 +18,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.vehicle.VehicleMoveEvent;
 
+import world.bentobox.bentobox.api.events.island.IslandProtectionRangeChangeEvent;
 import world.bentobox.bentobox.api.metadata.MetaDataValue;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
@@ -63,6 +64,13 @@ public class PlayerBorder implements Listener {
             e.getVehicle().getPassengers().stream().filter(en -> en instanceof Player).map(en -> (Player)en).forEach(p ->
             addon.getIslands().getIslandAt(p.getLocation()).ifPresent(i -> showBarrier(p, i)));
         }
+    }
+
+    @EventHandler(priority = EventPriority.NORMAL)
+    public void onProtectionRangeChange(IslandProtectionRangeChangeEvent e) {
+
+        // Cleans up barrier blocks that were on old range
+        e.getIsland().getPlayersOnIsland().forEach(player -> hideBarrier(User.getInstance(player)));
     }
 
     /**

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,6 +1,6 @@
 #
-# This list stores GameModes in which Challenges addon should not work.
-# To disable addon it is necessary to write its name in new line that starts with -. Example:
+# This list stores GameModes in which the addon should not work.
+# To disable the addon it is necessary to write its name in new line that starts with -. Example:
 # disabled-gamemodes:
 #  - BSkyBlock
 disabled-gamemodes: []

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,6 @@
+#
+# This list stores GameModes in which Challenges addon should not work.
+# To disable addon it is necessary to write its name in new line that starts with -. Example:
+# disabled-gamemodes:
+#  - BSkyBlock
+disabled-gamemodes: []


### PR DESCRIPTION
This PR fixes #48 . Though, there is something odd I have noticed.

If you increase range from 10 to 12, the old barriers will remove with this fix, but if you decrease it from 12 back to 10, there will be a small area on old 12 range border (actually a wall of 10x10 barrier blocks that will not go back to air), and I couldn't understand why