### PR TITLE
Fixes barrier blocks not removing on protection range change

### DIFF
--- a/src/main/java/world/bentobox/border/listeners/PlayerBorder.java
+++ b/src/main/java/world/bentobox/border/listeners/PlayerBorder.java
@@ -18,6 +18,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.vehicle.VehicleMoveEvent;
 
+import world.bentobox.bentobox.api.events.island.IslandProtectionRangeChangeEvent;
 import world.bentobox.bentobox.api.metadata.MetaDataValue;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
@@ -63,6 +64,13 @@ public class PlayerBorder implements Listener {
             e.getVehicle().getPassengers().stream().filter(en -> en instanceof Player).map(en -> (Player)en).forEach(p ->
             addon.getIslands().getIslandAt(p.getLocation()).ifPresent(i -> showBarrier(p, i)));
         }
+    }
+
+    @EventHandler(priority = EventPriority.NORMAL)
+    public void onProtectionRangeChange(IslandProtectionRangeChangeEvent e) {
+
+        // Cleans up barrier blocks that were on old range
+        e.getIsland().getPlayersOnIsland().forEach(player -> hideBarrier(User.getInstance(player)));
     }
 
     /**


### PR DESCRIPTION
This PR fixes #48  . Though, there is something odd I have noticed.

If you increase range from 10 to 12, the old barriers will remove with this fix, but if you decrease it from 12 back to 10, there will be a small area on old 12 range border (actually a wall of 10x10 barrier blocks that will not go back to air), and I couldn't understand why