### PR TITLE
Add a clearer message when WBAPI is not found

### DIFF
--- a/src/main/java/world/bentobox/border/Border.java
+++ b/src/main/java/world/bentobox/border/Border.java
@@ -42,7 +42,9 @@ public final class Border extends Addon {
         if (getSettings().isUseWbapi()) {
             Plugin plugin = Bukkit.getPluginManager().getPlugin("WorldBorderAPI");
             if (plugin == null || !plugin.isEnabled()) {
-                logError("WorldBorderAPI not found. Download from https://github.com/yannicklamprecht/WorldBorderAPI/releases");
+                logError("WorldBorderAPI not found.");
+                logError("Either download it or turn this integration off from configuration by: `use-wbapi: false`");
+                logError("You can download from https://github.com/yannicklamprecht/WorldBorderAPI/releases");
                 logError("Disabling addon");
                 this.setState(State.DISABLED);
                 return;


### PR DESCRIPTION
It is not mandatory to use WorldBorderAPI, so it should be clear for the user
that they have a choice besides integrating with it.