### PR TITLE
Remove `hooked` field (refactor)

### DIFF
--- a/src/main/java/world/bentobox/border/Border.java
+++ b/src/main/java/world/bentobox/border/Border.java
@@ -22,8 +22,6 @@ public final class Border extends Addon {
 
     private Settings settings;
 
-    private boolean hooked;
-
     private Config<Settings> config = new Config<>(this, Settings.class);
 
     private @NonNull List<GameModeAddon> gameModes = new ArrayList<>();
@@ -55,7 +53,6 @@ public final class Border extends Addon {
 
             if (!this.settings.getDisabledGameModes().contains(gameModeAddon.getDescription().getName())) {
 
-                hooked = true;
                 gameModes.add(gameModeAddon);
 
                 log("Border hooking into " + gameModeAddon.getDescription().getName());
@@ -63,8 +60,7 @@ public final class Border extends Addon {
             }
         });
 
-        if (hooked) {
-            // Register listeners
+        if (gameModes.size() > 0) {
             registerListener(new PlayerListener(this));
             registerListener(playerBorder);
         }


### PR DESCRIPTION
Removed the `hooked` field because it was used locally and could be removed as a simple refactoring, resulting a shorter and simpler code.