### PR TITLE
Unify wording of WBAPI-excluded configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ This is a visual border only and not a barrier. It displays the 🚫 particle. T
 show-max-border: true
 ```
 
+### Show particles
+Only applies if WBAPI isn't used.
+
+Enable/disable the particles.
+
+```
+show-particles: true
+```
+
 ## Commands
 
 There is one command that turns the border on or off. Since Version 3.0.0 it requires a permission:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ use-wbapi: true
 ```
 
 ### Use barrier blocks.
-This only applies if you are not using WBAPI.
+Only applies if WBAPI isn't used.
 
 If true, the the border will use barrier blocks to prevent most players from exiting the border. If players do manage to exit it, they will get teleported back inside it. 
 
@@ -60,7 +60,7 @@ show-by-default: true
 
 ### Show max-protection range border.
 
-This only applies if you are not using WBAPI.
+Only applies if WBAPI isn't used.
 
 This is a visual border only and not a barrier. It displays the 🚫 particle. This is useful for game modes like Boxed where the player's protection area can move around.
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ show-max-border: true
 ### Show particles
 Only applies if WBAPI isn't used.
 
-Enable/disable the particles.
+Enables/disables all types of wall particles shown by the addon. 
 
 ```
 show-particles: true

--- a/src/main/java/world/bentobox/border/Settings.java
+++ b/src/main/java/world/bentobox/border/Settings.java
@@ -51,7 +51,7 @@ public class Settings implements ConfigObject {
 
     @ConfigComment("")
     @ConfigComment("Only applies if WBAPI isn't used.")
-    @ConfigComment("Enable/disable the particles")
+    @ConfigComment("Enables/disables all types of wall particles shown by the addon")
     @ConfigEntry(path = "show-particles")
     private boolean showParticles = true;
 

--- a/src/main/java/world/bentobox/border/Settings.java
+++ b/src/main/java/world/bentobox/border/Settings.java
@@ -33,8 +33,8 @@ public class Settings implements ConfigObject {
     private boolean returnTeleport = true;
 
     @ConfigComment("")
+    @ConfigComment("Only applies if WBAPI isn't used.")
     @ConfigComment("Use barrier blocks. If false, the border is indicated by particles only.")
-    @ConfigComment("Only applicable if vanilla world border is not used")
     @ConfigEntry(path = "use-barrier-blocks")
     private boolean useBarrierBlocks = true;
 
@@ -44,12 +44,14 @@ public class Settings implements ConfigObject {
     private boolean showByDefault= true;
 
     @ConfigComment("")
+    @ConfigComment("Only applies if WBAPI isn't used.")
     @ConfigComment("Show max-protection range border. This is a visual border only and not a barrier.")
     @ConfigEntry(path = "show-max-border")
     private boolean showMaxBorder= true;
 
     @ConfigComment("")
-    @ConfigComment("Show particles. If WBAPI isn't used, then enable/disable the particles")
+    @ConfigComment("Only applies if WBAPI isn't used.")
+    @ConfigComment("Enable/disable the particles")
     @ConfigEntry(path = "show-particles")
     private boolean showParticles = true;
 


### PR DESCRIPTION
Unify wording of WBAPI-excluded configuration values and add show-particles to README.

Edit:
I also just found out that there is documentation here on this website; is it updated automatically?
https://docs.bentobox.world/en/latest/addons/Border/
If not, I would recommend considering consolidating them, having redundant documentation in two places sounds a bad idea for me. We could just link that page in the README.