### PR TITLE
Disabling EnderPearls and Chorus Fruit teleportation outside protection range + fix

### DIFF
--- a/src/main/java/world/bentobox/border/listeners/PlayerListener.java
+++ b/src/main/java/world/bentobox/border/listeners/PlayerListener.java
@@ -71,14 +71,13 @@ public class PlayerListener implements Listener {
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onPlayerTeleport(PlayerTeleportEvent e) {
 			Player player = e.getPlayer();
+			Location to = e.getTo();
 
 			show.clearUser(User.getInstance(player));
 
-			if (!addon.inGameWorld(player.getWorld())) {
+			if (!addon.inGameWorld(to.getWorld())) {
 				return;
 			}
-
-			Location to = e.getTo();
 
 			TeleportCause cause = e.getCause();
 			boolean isBlacklistedCause = cause == TeleportCause.ENDER_PEARL || cause == TeleportCause.CHORUS_FRUIT;

--- a/src/main/java/world/bentobox/border/listeners/ShowVirtualWorldBorder.java
+++ b/src/main/java/world/bentobox/border/listeners/ShowVirtualWorldBorder.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.WorldBorder;
+import org.bukkit.World.Environment;
 import org.bukkit.entity.Player;
 
 import world.bentobox.bentobox.api.metadata.MetaDataValue;
@@ -32,6 +33,9 @@ public class ShowVirtualWorldBorder implements BorderShower {
             return;
         }
         Location l = island.getProtectionCenter();
+        if (player.getWorld().getEnvironment() == Environment.NETHER) {
+            l.multiply(8);
+        }
         WorldBorder wb = Bukkit.createWorldBorder();
         wb.setCenter(l);
         wb.setSize(island.getProtectionRange() * 2D);


### PR DESCRIPTION
Title

**Fixed:**
`outsideCheck` was using the Island's center instead of the island's protection range center in `locationIsOnIsland`
