### PR TITLE
feat: detect mounted players on entity

### DIFF
--- a/src/main/java/world/bentobox/border/listeners/PlayerListener.java
+++ b/src/main/java/world/bentobox/border/listeners/PlayerListener.java
@@ -1,6 +1,8 @@
 package world.bentobox.border.listeners;
 
 import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -10,6 +12,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -22,9 +25,12 @@ import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.event.vehicle.VehicleExitEvent;
 import org.bukkit.event.vehicle.VehicleMoveEvent;
+import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.util.RayTraceResult;
 import org.bukkit.util.Vector;
 
+import org.spigotmc.event.entity.EntityDismountEvent;
+import org.spigotmc.event.entity.EntityMountEvent;
 import world.bentobox.bentobox.api.events.island.IslandProtectionRangeChangeEvent;
 import world.bentobox.bentobox.api.metadata.MetaDataValue;
 import world.bentobox.bentobox.api.user.User;
@@ -42,6 +48,7 @@ public class PlayerListener implements Listener {
     private final Border addon;
     private Set<UUID> inTeleport;
     private final BorderShower show;
+    private Map<Player, BukkitTask> mountedPlayers = new HashMap<>();
 
     public PlayerListener(Border addon) {
         this.addon = addon;
@@ -165,6 +172,56 @@ public class PlayerListener implements Listener {
         }
         return addon.getIslands().getIslandAt(to).filter(i -> !i.onIsland(to)).isPresent();
     }
+
+        /**
+     * Runs a task while the player is mounting an entity and eject
+     * if the entity went outside the protection range
+     * @param event - event
+     */
+    @EventHandler
+    public void onEntityMount(EntityMountEvent event) {
+        Entity entity = event.getEntity();
+        if (!(entity instanceof Player player)) {
+            return;
+        }
+
+        mountedPlayers.put(player, Bukkit.getScheduler().runTaskTimer(addon.getPlugin(), () -> {
+            Location loc = player.getLocation();
+
+            if (!addon.inGameWorld(loc.getWorld())) {
+                return;
+            }
+            // Eject from mount if outside the protection range
+            if (addon.getIslands().getProtectedIslandAt(loc).isEmpty()) {
+                // Force the dismount event for custom entities
+                if (!event.getMount().eject()) {
+                    var dismountEvent = new EntityDismountEvent(player, event.getMount());
+                    Bukkit.getPluginManager().callEvent(dismountEvent);
+                }
+            }
+        }, 1, 20));
+    }
+
+    /**
+     * Cancel the running task if the player was mounting an entity
+     * @param event - event
+     */
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    public void onEntityDismount(EntityDismountEvent event) {
+        Entity entity = event.getEntity();
+        if (!(entity instanceof Player player)) {
+            return;
+        }
+
+        BukkitTask task = mountedPlayers.get(player);
+        if (task == null) {
+            return;
+        }
+
+        task.cancel();
+        mountedPlayers.remove(player);
+    }
+
 
     /**
      * Teleports a player back home if they use a vehicle to glitch out of the world border


### PR DESCRIPTION
Dismounts when the Entity is outside the protection range

**How does it work?**
When a player mounts an entity:
- add to a tmp Map
- run a task every second to check entity's position and eject if outside the protection range
- force the Dismount event if the `#eject` method returns false (for custom mounting plugins such as MCPets)
- Removes the player from the tmp Map when dismounted and cancel the task