### PR TITLE
Add explicit bordertype command

### DIFF
--- a/src/main/java/world/bentobox/border/Border.java
+++ b/src/main/java/world/bentobox/border/Border.java
@@ -14,6 +14,7 @@ import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.api.configuration.Config;
 import world.bentobox.bentobox.api.metadata.MetaDataValue;
 import world.bentobox.bentobox.util.Util;
+import world.bentobox.border.commands.BorderTypeCommand;
 import world.bentobox.border.commands.IslandBorderCommand;
 import world.bentobox.border.listeners.BorderShower;
 import world.bentobox.border.listeners.PlayerListener;
@@ -52,6 +53,7 @@ public class Border extends Addon {
 
                 log("Border hooking into " + gameModeAddon.getDescription().getName());
                 gameModeAddon.getPlayerCommand().ifPresent(c -> new IslandBorderCommand(this, c, "border"));
+                gameModeAddon.getPlayerCommand().ifPresent(c -> new BorderTypeCommand(this, c, "bordertype"));
             }
         });
 

--- a/src/main/java/world/bentobox/border/commands/BorderTypeCommand.java
+++ b/src/main/java/world/bentobox/border/commands/BorderTypeCommand.java
@@ -19,13 +19,12 @@ import world.bentobox.border.PerPlayerBorderProxy;
  */
 public final class BorderTypeCommand extends CompositeCommand {
 
-    public static final String BORDER_TYPE_COMMAND_PERM = "border.type";
     private final Border addon;
     private Island island;
     private final List<String> availableTypes;
 
-    public BorderTypeCommand(Border addon, CompositeCommand parent) {
-        super(addon, parent, "type");
+    public BorderTypeCommand(Border addon, CompositeCommand parent, String commandLabel) {
+        super(addon, parent, commandLabel);
         this.addon = addon;
         this.availableTypes = addon.getAvailableBorderTypesView()
                 .stream()
@@ -35,7 +34,7 @@ public final class BorderTypeCommand extends CompositeCommand {
 
     @Override
     public void setup() {
-        this.setPermission(BORDER_TYPE_COMMAND_PERM);
+        this.setPermission("border." + this.getLabel());
         this.setDescription("border.set-type.description");
         this.setOnlyPlayer(true);
     }

--- a/src/main/java/world/bentobox/border/commands/IslandBorderCommand.java
+++ b/src/main/java/world/bentobox/border/commands/IslandBorderCommand.java
@@ -28,7 +28,7 @@ public class IslandBorderCommand extends CompositeCommand {
         this.setOnlyPlayer(true);
         setConfigurableRankCommand();
 
-        new BorderTypeCommand(this.getAddon(), this);
+        new BorderTypeCommand(this.getAddon(), this, "type");
     }
 
     @Override

--- a/src/main/java/world/bentobox/border/listeners/PlayerListener.java
+++ b/src/main/java/world/bentobox/border/listeners/PlayerListener.java
@@ -39,7 +39,6 @@ import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.util.Util;
 import world.bentobox.border.Border;
 import world.bentobox.border.PerPlayerBorderProxy;
-import world.bentobox.border.commands.BorderTypeCommand;
 import world.bentobox.border.commands.IslandBorderCommand;
 
 /**
@@ -75,16 +74,16 @@ public class PlayerListener implements Listener {
         // Get the game mode that this player is in
         addon.getPlugin().getIWM().getAddon(e.getPlayer().getWorld()).map(gma -> gma.getPermissionPrefix()).filter(
                 permPrefix -> !e.getPlayer().hasPermission(permPrefix + IslandBorderCommand.BORDER_COMMAND_PERM))
-                .ifPresent(permPrefix -> {
-                    // Restore barrier on/off to default
-                    user.putMetaData(BorderShower.BORDER_STATE_META_DATA,
-                            new MetaDataValue(addon.getSettings().isShowByDefault()));
-                    if (!e.getPlayer().hasPermission(permPrefix + BorderTypeCommand.BORDER_TYPE_COMMAND_PERM)) {
+        .ifPresent(permPrefix -> {
+            // Restore barrier on/off to default
+            user.putMetaData(BorderShower.BORDER_STATE_META_DATA,
+                    new MetaDataValue(addon.getSettings().isShowByDefault()));
+            if (!e.getPlayer().hasPermission(permPrefix + "border.type") && !e.getPlayer().hasPermission(permPrefix + "border.bordertype")) {
                 // Restore default barrier type to player
                 MetaDataValue metaDataValue = new MetaDataValue(addon.getSettings().getType().getId());
                 user.putMetaData(PerPlayerBorderProxy.BORDER_BORDERTYPE_META_DATA, metaDataValue);                
             }
-                });
+        });
 
         // Show the border if required one tick after   
         Bukkit.getScheduler().runTask(addon.getPlugin(), () -> addon.getIslands().getIslandAt(e.getPlayer().getLocation()).ifPresent(i -> 
@@ -215,7 +214,7 @@ public class PlayerListener implements Listener {
         return addon.getIslands().getIslandAt(to).filter(i -> !i.onIsland(to)).isPresent();
     }
 
-        /**
+    /**
      * Runs a task while the player is mounting an entity and eject
      * if the entity went outside the protection range
      * @param event - event

--- a/src/main/resources/addon.yml
+++ b/src/main/resources/addon.yml
@@ -15,3 +15,6 @@ permissions:
   '[gamemode].border.type':
     description: Player can use border type setting command
     default: true
+  '[gamemode].bordertype':
+    description: Player can use bordertype command to change the border type
+    default: false

--- a/src/test/java/world/bentobox/border/commands/BorderTypeCommandTest.java
+++ b/src/test/java/world/bentobox/border/commands/BorderTypeCommandTest.java
@@ -139,7 +139,7 @@ public class BorderTypeCommandTest {
         when(addon.getSettings()).thenReturn(settings);
 
 
-        ic = new BorderTypeCommand(addon, ac);
+        ic = new BorderTypeCommand(addon, ac, "type");
     }
 
     /**

--- a/src/test/java/world/bentobox/border/commands/BorderTypeCommandTest.java
+++ b/src/test/java/world/bentobox/border/commands/BorderTypeCommandTest.java
@@ -23,7 +23,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -140,13 +139,6 @@ public class BorderTypeCommandTest {
 
 
         ic = new BorderTypeCommand(addon, ac, "type");
-    }
-
-    /**
-     * @throws java.lang.Exception
-     */
-    @After
-    public void tearDown() throws Exception {
     }
 
     /**


### PR DESCRIPTION
#102 

Adds a `bordertype` command in addition to the `border type` command.

The permission is `[gamemode].border.bordertype` so it can be enabled/disabled by permissions.