### PR TITLE
Release 4.8.4

### DIFF
--- a/.github/workflows/modrinth-publish.yml
+++ b/.github/workflows/modrinth-publish.yml
@@ -40,4 +40,4 @@ jobs:
           game-versions: |-
             1.21.4
             1.21.5
-          files: /home/runner/work/BentoBox/Border/target/Border-${{ github.event.release.tag_name }}.jar
+          files: ${{ github.workspace }}/target/Border-${{ github.event.release.tag_name }}.jar

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <!-- Revision variable removes warning about dynamic version -->
         <revision>${build.version}-SNAPSHOT</revision>
         <!-- This allows to change between versions and snapshots. -->
-        <build.version>4.8.3</build.version>
+        <build.version>4.8.4</build.version>
         <build.number>-LOCAL</build.number>
         <!-- Sonar Cloud -->
         <sonar.projectKey>BentoBoxWorld_Border</sonar.projectKey>

--- a/src/main/java/world/bentobox/border/listeners/ShowWorldBorder.java
+++ b/src/main/java/world/bentobox/border/listeners/ShowWorldBorder.java
@@ -62,10 +62,10 @@ public class ShowWorldBorder implements BorderShower {
                 .orElseGet(() -> addon.getSettings().getColor());
         switch(borderColor) {
             case RED:
-                wb.changeSize(wb.getSize() - 0.1, MAX_TICKS);
+                wb.setSize(wb.getSize() - 0.1, MAX_TICKS);
                 break;
             case GREEN:
-                wb.changeSize(wb.getSize() + 0.1, MAX_TICKS);
+                wb.setSize(wb.getSize() + 0.1, MAX_TICKS);
                 break;
             case BLUE:
                 break;


### PR DESCRIPTION
## Summary
- **Fix: NoSuchMethodError on Paper/Purpur 1.21.10.** `WorldBorder.setSize(double, long)` is used instead of `changeSize`, restoring compatibility with 1.21.10 servers (Paper 1.21.11 made `setSize` a default method delegating to a new abstract `changeSize`, so jars built against 1.21.11 broke on 1.21.10).
- Cumulative develop changes since 4.6.0: per-player border color command and metadata, MiniMessage locale conversion, nether border fixes, item/death-drop containment, Java 21 / BentoBox 3.12 / Paper 1.21.11 toolchain, expanded test suite, CLAUDE.md, CI workflow fixes.

## Test plan
- [ ] `mvn verify` passes locally
- [ ] Smoke test on Paper/Purpur 1.21.10 server: `/<gm> bordertype vanilla` no longer throws NoSuchMethodError, and red/green border tints still animate
- [ ] Smoke test on Paper 1.21.11: vanilla border still renders and lerps correctly
- [ ] Barrier border type still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)