### PR TITLE
ci: bump pinned reusable workflow to fe4b1f0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   publish:
-    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@71bf927bce32586216baa6995f21852d944b98b9 # master
+    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@fe4b1f03c19f4fd4212020a06a07a7097923adec # master
     with:
       use_release_asset: "true"          # publish the jar attached to the release; do not rebuild
       hangar_slug: "Border"           # blank = skip Hangar


### PR DESCRIPTION
Picks up BentoBoxWorld/.github#11 — the publish prep step now reads the release
body from an environment variable instead of inlining it into the shell. Inline
interpolation left backticks and command-substitution live inside the shell
string, which broke the CurseForge/Hangar publish when release notes contained
inline code (as happened on BentoBox 3.18.1). No change to this repo's build.

Generated with Claude Code.