### PR TITLE
Declare the border colour and bordertype permissions

### DIFF
--- a/src/main/resources/addon.yml
+++ b/src/main/resources/addon.yml
@@ -15,6 +15,18 @@ permissions:
   '[gamemode].border.type':
     description: Player can use border type setting command
     default: true
-  '[gamemode].bordertype':
+  '[gamemode].border.bordertype':
     description: Player can use bordertype command to change the border type
     default: false
+  '[gamemode].border.color':
+    description: Player can use border color setting command
+    default: true
+  '[gamemode].border.color.red':
+    description: Player can set their border color to red
+    default: op
+  '[gamemode].border.color.green':
+    description: Player can set their border color to green
+    default: op
+  '[gamemode].border.color.blue':
+    description: Player can set their border color to blue
+    default: op


### PR DESCRIPTION
Found while investigating #179.

`addon.yml` did not declare the permissions the commands actually check:

* `[gamemode].border.color` — checked by `BorderColorCommand` (both `/[gamemode] border color` and `/[gamemode] bordercolor`). Undeclared, so it had no default and fell back to op only, which contradicts the documentation and stopped players from using the command at all. Declared `true`, with the colours themselves gated as documented.
* `[gamemode].border.color.red|green|blue` — checked in `BorderColorCommand#execute`, documented as op. Now declared.
* `[gamemode].bordertype` was declared but is never checked: `BorderTypeCommand` asks for `border.` + its label, i.e. `[gamemode].border.bordertype`. Renamed the declaration to the permission that is really used, keeping its `false` default.

This is not the cause of the exception in #179 — that is BentoBoxWorld/BentoBox#3042 — but it is why the colour command was unusable for the reporting player in the first place.

Border's tests pass (104 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6rYr6Z66LQz9XTbnbUupy