### PR TITLE
Release 4.8.5

### DIFF
--- a/.github/workflows/modrinth-publish.yml
+++ b/.github/workflows/modrinth-publish.yml
@@ -38,6 +38,14 @@ jobs:
             paper
             spigot
           game-versions: |-
-            1.21.4
             1.21.5
+            1.21.6
+            1.21.7
+            1.21.8
+            1.21.9
+            1.21.10
+            1.21.11
+            26.1
+            26.1.1
+            26.1.2
           files: ${{ github.workspace }}/target/Border-${{ github.event.release.tag_name }}.jar

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   publish:
-    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@fe4b1f03c19f4fd4212020a06a07a7097923adec # master
+    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@ca2dcd167e8db4e0f671a976080744dda43801a6 # master
     with:
       use_release_asset: "true"          # publish the jar attached to the release; do not rebuild
       hangar_slug: "Border"           # blank = skip Hangar

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+# Border — .github/workflows/publish.yml
+# CurseForge-first rollout. Hangar left blank; add its slug later to enable Hangar.
+
+name: Publish release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@main
+    with:
+      hangar_slug: ""
+      curseforge_id: "1515484"
+      game_versions: "26.1.2,26.1.1,26.1,1.21.11,1.21.10,1.21.9,1.21.8,1.21.7,1.21.6"
+    secrets:
+      HANGAR_API_KEY: ${{ secrets.HANGAR_API_KEY }}
+      CURSEFORGE_TOKEN: ${{ secrets.CURSEFORGE_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,19 +1,30 @@
 # Border — .github/workflows/publish.yml
-# CurseForge-first rollout. Hangar left blank; add its slug later to enable Hangar.
+# Publishes the jar attached to a GitHub release to CurseForge (and Hangar once a
+# slug is set) via the shared BentoBoxWorld/.github reusable workflow. It downloads
+# the release asset rather than rebuilding from source, so a dependency-repo outage
+# can't block publishing. Includes workflow_dispatch to (re)publish a given version.
 
-name: Publish release
+name: Publish release to CurseForge
 
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g. 1.2.3)"
+        required: true
+        type: string
 
 jobs:
   publish:
-    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@main
+    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@master
     with:
-      hangar_slug: ""
+      use_release_asset: "true"          # publish the jar attached to the release; do not rebuild
+      hangar_slug: ""                    # set the Hangar project slug to enable Hangar publishing
       curseforge_id: "1515484"
-      game_versions: "26.1.2,26.1.1,26.1,1.21.11,1.21.10,1.21.9,1.21.8,1.21.7,1.21.6"
+      game_versions: "26.2,26.1.2,26.1.1,26.1,1.21.11,1.21.10,1.21.9,1.21.8,1.21.7,1.21.6,1.21.5"
+      version: ${{ inputs.version }}     # empty on release events -> falls back to the release tag
     secrets:
       HANGAR_API_KEY: ${{ secrets.HANGAR_API_KEY }}
       CURSEFORGE_TOKEN: ${{ secrets.CURSEFORGE_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   publish:
-    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@ca2dcd167e8db4e0f671a976080744dda43801a6 # master
+    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@1f91a0edf72e8c86d671b3b8fdd3121ac6fb88e1 # master
     with:
       use_release_asset: "true"          # publish the jar attached to the release; do not rebuild
       hangar_slug: "Border"           # blank = skip Hangar

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   publish:
-    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@e0c5d98f5e6ef9ea7c9a28afad05f4c07bcde898 # master
+    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@71bf927bce32586216baa6995f21852d944b98b9 # master
     with:
       use_release_asset: "true"          # publish the jar attached to the release; do not rebuild
       hangar_slug: "Border"           # blank = skip Hangar

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   publish:
-    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@71bf927bce32586216baa6995f21852d944b98b9 # master
+    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@fe4b1f03c19f4fd4212020a06a07a7097923adec # master
     with:
       use_release_asset: "true"          # publish the jar attached to the release; do not rebuild
       hangar_slug: "Border"           # blank = skip Hangar

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,10 @@
 # Border — .github/workflows/publish.yml
-# Publishes the jar attached to a GitHub release to CurseForge (and Hangar once a
-# slug is set) via the shared BentoBoxWorld/.github reusable workflow. It downloads
-# the release asset rather than rebuilding from source, so a dependency-repo outage
-# can't block publishing. Includes workflow_dispatch to (re)publish a given version.
+# Publishes the jar attached to a GitHub release to CurseForge and Hangar via the
+# shared BentoBoxWorld/.github reusable workflow. Downloads the release asset instead of
+# rebuilding from source. The reusable workflow is pinned to a commit SHA (Sonar
+# githubactions:S7637). workflow_dispatch lets you (re)publish a given version.
 
-name: Publish release to CurseForge
+name: Publish release to CurseForge and Hangar
 
 on:
   release:
@@ -18,10 +18,10 @@ on:
 
 jobs:
   publish:
-    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@master
+    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@e0c5d98f5e6ef9ea7c9a28afad05f4c07bcde898 # master
     with:
       use_release_asset: "true"          # publish the jar attached to the release; do not rebuild
-      hangar_slug: ""                    # set the Hangar project slug to enable Hangar publishing
+      hangar_slug: "Border"           # blank = skip Hangar
       curseforge_id: "1515484"
       game_versions: "26.2,26.1.2,26.1.1,26.1,1.21.11,1.21.10,1.21.9,1.21.8,1.21.7,1.21.6,1.21.5"
       version: ${{ inputs.version }}     # empty on release events -> falls back to the release tag

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <!-- Revision variable removes warning about dynamic version -->
         <revision>${build.version}-SNAPSHOT</revision>
         <!-- This allows to change between versions and snapshots. -->
-        <build.version>4.8.4</build.version>
+        <build.version>4.8.5</build.version>
         <build.number>-LOCAL</build.number>
         <!-- Sonar Cloud -->
         <sonar.projectKey>BentoBoxWorld_Border</sonar.projectKey>

--- a/pom.xml
+++ b/pom.xml
@@ -142,9 +142,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.github.MockBukkit</groupId>
-            <artifactId>MockBukkit</artifactId>
-            <version>v1.21-SNAPSHOT</version>
+            <groupId>org.mockbukkit.mockbukkit</groupId>
+            <artifactId>mockbukkit-v1.21</artifactId>
+            <version>4.110.0</version>
             <scope>test</scope>
          </dependency>
         <dependency>

--- a/src/main/java/world/bentobox/border/listeners/PlayerListener.java
+++ b/src/main/java/world/bentobox/border/listeners/PlayerListener.java
@@ -1,7 +1,9 @@
 package world.bentobox.border.listeners;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -23,6 +25,7 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.event.entity.EntityDismountEvent;
 import org.bukkit.event.entity.EntityMountEvent;
+import org.bukkit.event.entity.ItemSpawnEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
@@ -71,10 +74,18 @@ import world.bentobox.border.commands.IslandBorderCommand;
 public class PlayerListener implements Listener {
 
     private static final Vector XZ = new Vector(1, 0, 1);
+    /** How close to a death spot, in blocks, an item must spawn to count as a death drop. */
+    private static final double DEATH_DROP_RADIUS_SQUARED = 5 * 5D;
     private final Border addon;
     private final Set<UUID> inTeleport;
     private final BorderShower show;
     private final Map<Player, BukkitTask> mountedPlayers = new HashMap<>();
+    /** Death spots whose drops the server has yet to spawn. Entries last one tick. */
+    private final List<DeathDrops> pendingDeathDrops = new ArrayList<>();
+
+    /** A death whose drops will spawn this tick, and the island they must stay on. */
+    private record DeathDrops(Location location, Island island) {
+    }
 
     /**
      * Constructs a new PlayerListener.
@@ -500,21 +511,52 @@ public class PlayerListener implements Listener {
     }
 
     /**
-     * Bounces items back to inside the barrier if dropped when a player dies
+     * Remembers where a player died so that the items the server is about to drop there can
+     * be bounced back inside the barrier.
+     * <p>
+     * The drops list must not be touched here: taking the items out of the event and dropping
+     * them by hand breaks every plugin that stores death drops (death chests, graves, keep
+     * inventory). Instead this runs at MONITOR, after those plugins have decided what happens
+     * to the items, and only notes the death spot. Whatever the server then actually drops is
+     * picked up in {@link #onDeathDropSpawn(ItemSpawnEvent)} and tracked from there.
+     *
+     * @param event event
+     */
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onPlayerDeath(PlayerDeathEvent event) {
+        if (!addon.getSettings().isBounceBack()
+                || event.getDrops().isEmpty()
+                || !addon.inGameWorld(event.getPlayer().getWorld())
+                || !isOn(event.getPlayer())) {
+            return;
+        }
+        Location loc = event.getPlayer().getLocation();
+        addon.getIslands().getIslandAt(Objects.requireNonNull(loc)).ifPresent(is -> {
+            DeathDrops deathDrops = new DeathDrops(loc, is);
+            pendingDeathDrops.add(deathDrops);
+            // The server spawns the drops in this tick, straight after the event returns
+            Bukkit.getScheduler().runTask(addon.getPlugin(), () -> pendingDeathDrops.remove(deathDrops));
+        });
+    }
+
+    /**
+     * Tracks death drops as the server spawns them, so they cannot leave the island's
+     * protection zone. Items spawning this tick near a recorded death spot are the drops the
+     * server kept after every plugin had its say on the death event.
      *
      * @param event event
      */
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
-    public void onPlayerDeath(PlayerDeathEvent event) {
-        if (addon.getSettings().isBounceBack()
-                && addon.inGameWorld(event.getPlayer().getWorld())
-                && isOn(event.getPlayer())) {
-            Location loc = event.getPlayer().getLocation();
-            addon.getIslands().getIslandAt(Objects.requireNonNull(loc)).ifPresent(is -> {
-                event.getDrops().forEach(item -> trackItem(event.getPlayer().getWorld().dropItemNaturally(loc, item), is));
-                event.getDrops().clear(); // We handled them
-            });
+    public void onDeathDropSpawn(ItemSpawnEvent event) {
+        if (pendingDeathDrops.isEmpty()) {
+            return;
         }
+        Location loc = event.getLocation();
+        pendingDeathDrops.stream()
+                .filter(dd -> Objects.equals(loc.getWorld(), dd.location().getWorld()))
+                .filter(dd -> loc.distanceSquared(dd.location()) <= DEATH_DROP_RADIUS_SQUARED)
+                .findFirst()
+                .ifPresent(dd -> trackItem(event.getEntity(), dd.island()));
     }
 
     /**

--- a/src/main/resources/addon.yml
+++ b/src/main/resources/addon.yml
@@ -15,6 +15,18 @@ permissions:
   '[gamemode].border.type':
     description: Player can use border type setting command
     default: true
-  '[gamemode].bordertype':
+  '[gamemode].border.bordertype':
     description: Player can use bordertype command to change the border type
     default: false
+  '[gamemode].border.color':
+    description: Player can use border color setting command
+    default: true
+  '[gamemode].border.color.red':
+    description: Player can set their border color to red
+    default: op
+  '[gamemode].border.color.green':
+    description: Player can set their border color to green
+    default: op
+  '[gamemode].border.color.blue':
+    description: Player can set their border color to blue
+    default: op

--- a/src/test/java/world/bentobox/border/listeners/PlayerListenerTest.java
+++ b/src/test/java/world/bentobox/border/listeners/PlayerListenerTest.java
@@ -1,5 +1,6 @@
 package world.bentobox.border.listeners;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -11,6 +12,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -19,8 +21,12 @@ import java.util.concurrent.CompletableFuture;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
+import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Vehicle;
+import org.bukkit.event.entity.ItemSpawnEvent;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
@@ -74,6 +80,16 @@ class PlayerListenerTest extends CommonTestSetup {
     private Vehicle vehicle;
     @Mock
     private GameModeAddon gma;
+    @Mock
+    private PlayerDeathEvent deathEvent;
+    @Mock
+    private ItemSpawnEvent itemSpawnEvent;
+    @Mock
+    private Item item;
+    @Mock
+    private ItemStack itemStack;
+    @Mock
+    private Location farAway;
     
     private MockedStatic<User> mockedUser;
 
@@ -462,6 +478,86 @@ class PlayerListenerTest extends CommonTestSetup {
         pl.onProtectionRangeChange(event);
         verify(show).hideBorder(user);
         verify(show).showBorder(player, island);
+    }
+
+    /**
+     * Test method for {@link world.bentobox.border.listeners.PlayerListener#onPlayerDeath(org.bukkit.event.entity.PlayerDeathEvent)}.
+     * The drops must be left in the event for death chest plugins and the server to handle.
+     */
+    @Test
+    void testOnPlayerDeathLeavesDropsAlone() {
+        List<ItemStack> drops = new ArrayList<>();
+        drops.add(itemStack);
+        when(deathEvent.getPlayer()).thenReturn(player);
+        when(deathEvent.getDrops()).thenReturn(drops);
+        pl.onPlayerDeath(deathEvent);
+        assertEquals(1, drops.size());
+        verify(world, never()).dropItemNaturally(any(Location.class), any(ItemStack.class));
+        // The death spot is remembered, and forgotten again next tick
+        verify(sch).runTask(eq(plugin), any(Runnable.class));
+    }
+
+    /**
+     * Test method for {@link world.bentobox.border.listeners.PlayerListener#onDeathDropSpawn(org.bukkit.event.entity.ItemSpawnEvent)}.
+     * An item spawning at a fresh death spot is a death drop and gets the bounce-back tracking.
+     */
+    @Test
+    void testDeathDropsAreTrackedWhenTheySpawn() {
+        List<ItemStack> drops = new ArrayList<>();
+        drops.add(itemStack);
+        when(deathEvent.getPlayer()).thenReturn(player);
+        when(deathEvent.getDrops()).thenReturn(drops);
+        pl.onPlayerDeath(deathEvent);
+        when(itemSpawnEvent.getLocation()).thenReturn(to);
+        when(itemSpawnEvent.getEntity()).thenReturn(item);
+        pl.onDeathDropSpawn(itemSpawnEvent);
+        verify(sch).runTaskTimer(eq(plugin), any(Runnable.class), eq(1L), eq(1L));
+    }
+
+    /**
+     * Test method for {@link world.bentobox.border.listeners.PlayerListener#onDeathDropSpawn(org.bukkit.event.entity.ItemSpawnEvent)}.
+     */
+    @Test
+    void testItemSpawnWithNoRecentDeathIsIgnored() {
+        pl.onDeathDropSpawn(itemSpawnEvent);
+        verify(sch, never()).runTaskTimer(any(), any(Runnable.class), eq(1L), eq(1L));
+    }
+
+    /**
+     * Test method for {@link world.bentobox.border.listeners.PlayerListener#onDeathDropSpawn(org.bukkit.event.entity.ItemSpawnEvent)}.
+     */
+    @Test
+    void testItemSpawnFarFromDeathIsNotTracked() {
+        List<ItemStack> drops = new ArrayList<>();
+        drops.add(itemStack);
+        when(deathEvent.getPlayer()).thenReturn(player);
+        when(deathEvent.getDrops()).thenReturn(drops);
+        pl.onPlayerDeath(deathEvent);
+        when(farAway.getWorld()).thenReturn(world);
+        when(farAway.distanceSquared(to)).thenReturn(100.0);
+        when(itemSpawnEvent.getLocation()).thenReturn(farAway);
+        pl.onDeathDropSpawn(itemSpawnEvent);
+        verify(sch, never()).runTaskTimer(any(), any(Runnable.class), eq(1L), eq(1L));
+    }
+
+    /**
+     * Test method for {@link world.bentobox.border.listeners.PlayerListener#onPlayerDeath(org.bukkit.event.entity.PlayerDeathEvent)}.
+     */
+    @Test
+    void testOnPlayerDeathBounceBackDisabled() {
+        settings.setBounceBack(false);
+        pl.onPlayerDeath(deathEvent);
+        verify(sch, never()).runTask(any(), any(Runnable.class));
+    }
+
+    /**
+     * Test method for {@link world.bentobox.border.listeners.PlayerListener#onPlayerDeath(org.bukkit.event.entity.PlayerDeathEvent)}.
+     */
+    @Test
+    void testOnPlayerDeathNoDrops() {
+        when(deathEvent.getDrops()).thenReturn(new ArrayList<>());
+        pl.onPlayerDeath(deathEvent);
+        verify(sch, never()).runTask(any(), any(Runnable.class));
     }
 
 }


### PR DESCRIPTION
Release 4.8.5 — compatibility and permissions patch.

## Bug Fixes

* **Death drops no longer hijacked from other plugins** — the bounce-back protection added in 4.7.0 emptied `PlayerDeathEvent.getDrops()` at NORMAL priority, silently breaking DeathChest, grave plugins and keep-inventory features. `onPlayerDeath` now runs at MONITOR and only records the death spot; a new `ItemSpawnEvent` handler bounces back the items the server actually spawns. [#182]
* 🔺 **Border colour and type permissions were never declared** — `[gamemode].border.color` was undeclared, so it fell back to op-only and players could not use the colour command. Declared `true`, with the individual colours gated `op` as documented. `[gamemode].bordertype` (declared but never checked) renamed to `[gamemode].border.bordertype`. [#180], found while investigating #179

## Other

* CurseForge and Hangar publishing on release [#176]
* Modrinth game versions updated to 1.21.5 – 1.21.11 and 26.1.x [#175]
* MockBukkit pinned to Maven Central 4.110.0

Draft release notes for 4.8.5 are prepared on GitHub for review.